### PR TITLE
fixed Error: Cannot find module 'bootstrap-list-filter'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bootstrap-list-filter",
   "version": "0.2.0",
   "description": "Search widget to filter Bootstrap lists",
+  "main": "bootstrap-list-filter.src.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:stefanocudini/bootstrap-list-filter.git"


### PR DESCRIPTION
I am using this module with browserify. The require method can't find the module due to the missing main property.
