### PR TITLE
bootstrap peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bootstrap": "*"
   },
   "peerDependencies": {
-    "bootstrap": "^3.4.5"
+    "bootstrap": "^3.3.5"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
3.4.5 does not exist, can't install it via npm